### PR TITLE
Change distribution to 'This community only'

### DIFF
--- a/misp_stix_converter/converters/buildMISPAttribute.py
+++ b/misp_stix_converter/converters/buildMISPAttribute.py
@@ -261,7 +261,7 @@ def buildEvent(pkg, **kwargs):
 
     log.debug("Seting up MISPEvent...")
     event = mispevent.MISPEvent()
-    event.distribution = kwargs.get("distribution", 0)
+    event.distribution = kwargs.get("distribution", 1)
     event.threat_level_id = kwargs.get("threat_level_id", 3)
     event.analysis = kwargs.get("analysis", 0)
     event.info = title


### PR DESCRIPTION
Hello all,

Change distribution level to <code>This community only</code> (value: 1). <code>This community only</code> is the default distribution level used by MISP for any new event.

Don't hesitate to contact me if you need some help and if you have some question.

devnull-
